### PR TITLE
Clean unused CAN message buffers

### DIFF
--- a/src/vw_mlb_charger.cpp
+++ b/src/vw_mlb_charger.cpp
@@ -20,9 +20,6 @@
 #include <vw_mlb_charger.h>
 #define MLB_CHARGER_STANDALONE
 
-uCAN_MSG txMsg;
-uint8_t CanMsgBuf[8];
-
 bool VWMLBClass::ControlCharge(bool RunCh, bool ACReq)
 {
     if (charger_status.HVLM_Plug_Status > 1 && RunCh)


### PR DESCRIPTION
## Summary
- remove unused `txMsg` and `CanMsgBuf` variables from `vw_mlb_charger.cpp`

## Testing
- `make Test` *(fails: No rule to make target `my_string.o`)*

------
https://chatgpt.com/codex/tasks/task_e_688659fa7c50832b91203a86c0420c2e