### PR TITLE
Refine MLB charger simulation parameters

### DIFF
--- a/include/param_prj.h
+++ b/include/param_prj.h
@@ -28,7 +28,7 @@
    2. Temporary parameters (id = 0)
    3. Display values
  */
-// Next param id (increase when adding new parameter!): 153
+// Next param id (increase when adding new parameter!): 166
 /*              category     name         unit       min     max     default id */
 #define PARAM_LIST                                                         \
     PARAM_ENTRY(CAT_SETUP, Inverter, INVMODES, 0, 8, 0, 5)                 \
@@ -287,34 +287,22 @@
     VALUE_ENTRY(mlb_chr_ChargerWarning, "dig", 2140)                       \
     VALUE_ENTRY(mlb_chr_ChargerFault, "dig", 2141)                         \
     VALUE_ENTRY(mlb_chr_OutputVolts, "V", 2142)                            \
-    VALUE_ENTRY(mlb_chr_VCU_SOC, "%", 2143)                                \
-    VALUE_ENTRY(mlb_chr_VCU_SOC_Limit, "%", 2144)                          \
-    VALUE_ENTRY(mlb_chr_VCU_UDCmin, "V", 2145)                             \
-    VALUE_ENTRY(mlb_chr_VCU_Current_SP, "A", 2146)                         \
-    VALUE_ENTRY(mlb_chr_VCU_Volt_SP, "V", 2147)                            \
-    VALUE_ENTRY(mlb_chr_BMS_Pack_Voltage, "V", 2148)                       \
-    VALUE_ENTRY(mlb_chr_VCU_UDCmax, "V", 2149)                             \
-    VALUE_ENTRY(mlb_chr_BMS_Highest_Cell_Temp, "°C", 2150)                 \
-    VALUE_ENTRY(mlb_chr_BMS_Lowest_Cell_Temp, "°C", 2151)                  \
-    VALUE_ENTRY(mlb_chr_BMS_Highest_Cell_Volt, "mV", 2152)                 \
-    VALUE_ENTRY(mlb_chr_BMS_Lowest_Cell_Volt, "mV", 2153)                  \
-    VALUE_ENTRY(mlb_chr_VCUChargeRequest, "dig", 2154)                     \
-    VALUE_ENTRY(mlb_chr_VehicleLockState, "dig", 2155)                     \
-    VALUE_ENTRY(mlb_chr_SOCx10, "dig", 2156)                               \
-    VALUE_ENTRY(mlb_chr_SOC_Targetx10, "dig", 2157)                        \
-    VALUE_ENTRY(mlb_chr_BMSMinVolt, "V", 2158)                             \
-    VALUE_ENTRY(mlb_chr_IDCSetpnt, "A", 2159)                              \
-    VALUE_ENTRY(mlb_chr_HVDCSetpnt, "V", 2160)                             \
-    VALUE_ENTRY(mlb_chr_BMSBattCellSumx10, "dig", 2161)                    \
-    VALUE_ENTRY(mlb_chr_BMSMaxVolt, "V", 2162)                             \
-    VALUE_ENTRY(mlb_chr_BMS_Cell_H_Tempx10, "dig", 2163)                   \
-    VALUE_ENTRY(mlb_chr_BMS_Cell_L_Tempx10, "dig", 2164)                   \
-    VALUE_ENTRY(mlb_chr_BMS_Cell_H_mV, "mV", 2165)                         \
-    VALUE_ENTRY(mlb_chr_BMS_Cell_L_mV, "mV", 2166)                         \
-    VALUE_ENTRY(mlb_chr_Activation_Crg, "dig", 2167)                       \
-    VALUE_ENTRY(mlb_chr_LockSim, "dig", 2168)
+    /* simulation parameters for standalone charger testing */
+    PARAM_ENTRY(CAT_MLB_SIM, mlb_chr_sim_SOC, "%%", 0, 100, 50, 153) \
+    PARAM_ENTRY(CAT_MLB_SIM, mlb_chr_sim_SOC_Target, "%%", 0, 100, 100, 154) \
+    PARAM_ENTRY(CAT_MLB_SIM, mlb_chr_sim_BMSMinVolt, "V", 0, 1000, 300, 155) \
+    PARAM_ENTRY(CAT_MLB_SIM, mlb_chr_sim_IDCSetpnt, "A", 0, 200, 10, 156) \
+    PARAM_ENTRY(CAT_MLB_SIM, mlb_chr_sim_HVDCSetpnt, "V", 0, 1000, 400, 157) \
+    PARAM_ENTRY(CAT_MLB_SIM, mlb_chr_sim_BMSBattCellSum, "V", 0, 1000, 350, 158) \
+    PARAM_ENTRY(CAT_MLB_SIM, mlb_chr_sim_BMSMaxVolt, "V", 0, 1000, 450, 159) \
+    PARAM_ENTRY(CAT_MLB_SIM, mlb_chr_sim_BMS_Cell_H_Temp, "°C", -40, 100, 25, 160) \
+    PARAM_ENTRY(CAT_MLB_SIM, mlb_chr_sim_BMS_Cell_L_Temp, "°C", -40, 100, 20, 161) \
+    PARAM_ENTRY(CAT_MLB_SIM, mlb_chr_sim_BMS_Cell_H_mV, "mV", 0, 5000, 4200, 162) \
+    PARAM_ENTRY(CAT_MLB_SIM, mlb_chr_sim_BMS_Cell_L_mV, "mV", 0, 5000, 3000, 163) \
+    PARAM_ENTRY(CAT_MLB_SIM, mlb_chr_sim_Activation_Crg, "dig", 0, 1, 0, 164) \
+    PARAM_ENTRY(CAT_MLB_SIM, mlb_chr_sim_Lock, "dig", 0, 1, 0, 165)
 
-// Next value Id: 2169
+// Next value Id: 2143
 
 // Dead params
 /*
@@ -379,6 +367,7 @@
 #define CAT_SHUNT "ISA Shunt Control"
 #define CAT_IOPINS "General Purpose I/O"
 #define CAT_PWM "PWM Control"
+#define CAT_MLB_SIM "MLB Charger Sim"
 #define MotorsAct "0=Mg1and2, 1=Mg1, 2=Mg2, 3=BlendingMG2and1"
 #define PumpOutType "0=GS450hOil, 1=TachoOut, 2=SpeedoOut"
 #define LIMITREASON "0=None, 1=UDClimLow, 2=UDClimHigh, 4=IDClimLow, 8=IDClimHigh, 16=TempLim"

--- a/src/vw_mlb_charger.cpp
+++ b/src/vw_mlb_charger.cpp
@@ -185,38 +185,23 @@ void VWMLBClass::TagParams() // To make code portable between standalone (more p
     Param::SetInt(Param::mlb_chr_ChargerFault, charger_status.LAD_ChargerFault);
     Param::SetInt(Param::mlb_chr_OutputVolts, charger_status.HVLM_Output_Voltage_HV);
 
-    //copy over (manually entered) parameters into values to control the charger
-    Param::SetFloat(Param::mlb_chr_VCU_SOC, (Param::GetInt(Param::mlb_chr_SOCx10)));
-    Param::SetFloat(Param::mlb_chr_VCU_SOC_Limit, Param::GetInt(Param::mlb_chr_SOC_Targetx10));
-    Param::SetInt(Param::mlb_chr_VCU_UDCmin, Param::GetInt(Param::mlb_chr_BMSMinVolt));
-    Param::SetInt(Param::mlb_chr_VCU_Current_SP, Param::GetInt(Param::mlb_chr_IDCSetpnt));
-    Param::SetInt(Param::mlb_chr_VCU_Volt_SP, Param::GetInt(Param::mlb_chr_HVDCSetpnt));
-    Param::SetFloat(Param::mlb_chr_BMS_Pack_Voltage, (Param::GetInt(Param::mlb_chr_BMSBattCellSumx10) / 10));
-    Param::SetInt(Param::mlb_chr_VCU_UDCmax, Param::GetInt(Param::mlb_chr_BMSMaxVolt));
-    Param::SetFloat(Param::mlb_chr_BMS_Highest_Cell_Temp, (Param::GetInt(Param::mlb_chr_BMS_Cell_H_Tempx10)) / 10);
-    Param::SetFloat(Param::mlb_chr_BMS_Lowest_Cell_Temp, (Param::GetInt(Param::mlb_chr_BMS_Cell_L_Tempx10)) / 10);
-    Param::SetInt(Param::mlb_chr_BMS_Highest_Cell_Volt, Param::GetInt(Param::mlb_chr_BMS_Cell_H_mV));
-    Param::SetInt(Param::mlb_chr_BMS_Lowest_Cell_Volt, Param::GetInt(Param::mlb_chr_BMS_Cell_L_mV));
-    Param::SetInt(Param::mlb_chr_VCUChargeRequest, Param::GetInt(Param::mlb_chr_Activation_Crg));
-    Param::SetInt(Param::mlb_chr_VehicleLockState, Param::GetInt(Param::mlb_chr_LockSim));
-
-    //copy over the values to control the charger into the internal data structure  
-    battery_status.SOCx10 = (Param::GetInt(Param::mlb_chr_VCU_SOC));
-    battery_status.SOC_Targetx10 = Param::GetInt(Param::mlb_chr_VCU_SOC_Limit);
-    battery_status.BMSMinVolt = Param::GetInt(Param::mlb_chr_VCU_UDCmin);
-    charger_params.IDCSetpnt = Param::GetInt(Param::mlb_chr_VCU_Current_SP);
-    charger_params.HVDCSetpnt = Param::GetInt(Param::mlb_chr_VCU_Volt_SP);
-    battery_status.BMSBattCellSumx10 = Param::GetInt(Param::mlb_chr_BMS_Pack_Voltage);
-    battery_status.BMSMaxVolt = Param::GetInt(Param::mlb_chr_VCU_UDCmax);
-    battery_status.BMS_Cell_H_Tempx10 = Param::GetInt(Param::mlb_chr_BMS_Highest_Cell_Temp) * 10;
-    battery_status.BMS_Cell_L_Tempx10 = Param::GetInt(Param::mlb_chr_BMS_Lowest_Cell_Temp) * 10;
-    battery_status.BMS_Cell_H_mV = Param::GetInt(Param::mlb_chr_BMS_Highest_Cell_Volt);
-    battery_status.BMS_Cell_L_mV = Param::GetInt(Param::mlb_chr_BMS_Lowest_Cell_Volt);
-    mlb_state.ZV_verriegelt_extern_ist = Param::GetInt(Param::mlb_chr_VehicleLockState);
+    //copy parameters directly from user settable simulation values
+    battery_status.SOCx10 = Param::GetInt(Param::mlb_chr_sim_SOC) * 10;
+    battery_status.SOC_Targetx10 = Param::GetInt(Param::mlb_chr_sim_SOC_Target) * 10;
+    battery_status.BMSMinVolt = Param::GetInt(Param::mlb_chr_sim_BMSMinVolt);
+    charger_params.IDCSetpnt = Param::GetInt(Param::mlb_chr_sim_IDCSetpnt);
+    charger_params.HVDCSetpnt = Param::GetInt(Param::mlb_chr_sim_HVDCSetpnt);
+    battery_status.BMSBattCellSumx10 = Param::GetInt(Param::mlb_chr_sim_BMSBattCellSum) * 10;
+    battery_status.BMSMaxVolt = Param::GetInt(Param::mlb_chr_sim_BMSMaxVolt);
+    battery_status.BMS_Cell_H_Tempx10 = Param::GetInt(Param::mlb_chr_sim_BMS_Cell_H_Temp) * 10;
+    battery_status.BMS_Cell_L_Tempx10 = Param::GetInt(Param::mlb_chr_sim_BMS_Cell_L_Temp) * 10;
+    battery_status.BMS_Cell_H_mV = Param::GetInt(Param::mlb_chr_sim_BMS_Cell_H_mV);
+    battery_status.BMS_Cell_L_mV = Param::GetInt(Param::mlb_chr_sim_BMS_Cell_L_mV);
+    mlb_state.ZV_verriegelt_extern_ist = Param::GetInt(Param::mlb_chr_sim_Lock);
 #else
     //normal operation mode with parameters exchange. and reduced parameter set
     battery_status.SOCx10 = int(Param::GetFloat(Param::SOC) * 10);
-    battery_status.SOC_Targetx10 = 1000; // Param::GetInt(Param::mlb_chr_VCU_SOC_Limit);
+    battery_status.SOC_Targetx10 = 1000;
     battery_status.CapkWhx10 = int(Param::GetFloat(Param::BattCap) * 10);
     battery_status.BMSMinVolt = Param::GetInt(Param::udcmin);
     charger_params.HVpwr = Param::GetInt(Param::Pwrspnt);


### PR DESCRIPTION
## Summary
- add dedicated MLB charger sim category
- rename standalone charger parameters to `mlb_chr_sim_*`
- store sim parameters using base units instead of x10
- update charger to scale new values when copying into runtime data

## Testing
- `make Test` *(fails: No rule to make target 'my_string.o')*

------
https://chatgpt.com/codex/tasks/task_e_688695deadd0832ba82b0e9e021cc4a7