### PR TITLE
Allow charger simulation mode to override activation state

### DIFF
--- a/src/vw_mlb_charger.cpp
+++ b/src/vw_mlb_charger.cpp
@@ -21,10 +21,22 @@
 #include "params.h"
 
 #define MLB_CHARGER_STANDALONE
+// Define MLB_CHARGER_SIM to enable simulation behaviour for the charger. When
+// enabled the charger activation state will be taken from the simulation
+// parameter instead of being decided by ControlCharge().
+//#define MLB_CHARGER_SIM
 
 
 bool VWMLBClass::ControlCharge(bool RunCh, bool ACReq)
 {
+#ifdef MLB_CHARGER_SIM
+    /*
+     * In simulation mode the activation request is supplied via parameter
+     * mlb_chr_sim_Activation_Crg.  Do not override it here.
+     */
+    charger_params.activate = Param::GetInt(Param::mlb_chr_sim_Activation_Crg);
+    return charger_params.activate;
+#else
     if (charger_status.HVLM_Plug_Status > 1 && RunCh)
     {
         charger_params.activate = 1;
@@ -35,6 +47,7 @@ bool VWMLBClass::ControlCharge(bool RunCh, bool ACReq)
         charger_params.activate = 0;
         return false;
     }
+#endif
 }
 
 void VWMLBClass::Task10Ms()


### PR DESCRIPTION
## Summary
- document `MLB_CHARGER_SIM` macro
- allow simulation parameter `mlb_chr_sim_Activation_Crg` to control charger activation when `MLB_CHARGER_SIM` is defined

## Testing
- `make clean && make` in `test` directory *(fails: No rule to make target 'my_string.o')*

------
https://chatgpt.com/codex/tasks/task_e_68869c1caf94832baa55b6152949f75b