### PR TITLE
Document MLB charger mode values

### DIFF
--- a/include/param_prj.h
+++ b/include/param_prj.h
@@ -267,7 +267,7 @@
     VALUE_ENTRY(mlb_chr_ChargerErrorStatus, HVLM_ERRORSTATUS, 2120)                           \
     VALUE_ENTRY(mlb_chr_PlugStatus, HVLM_PLUGSTATUS, 2121)                                   \
     VALUE_ENTRY(mlb_chr_LoadRequest, HVLM_LOADREQ, 2122)                                  \
-    VALUE_ENTRY(mlb_chr_ChargerState, "dig", 2123)                                 \
+    VALUE_ENTRY(mlb_chr_ChargerState, HVLM_CHARGERMODE, 2123)                                 \
     VALUE_ENTRY(mlb_chr_Charger_AC_Volt_RMS, "V", 2124)                            \
     VALUE_ENTRY(mlb_chr_Charger_VoltageOut_HV, "V", 2125)                          \
     VALUE_ENTRY(mlb_chr_Charger_CurrentOut_HV, "A", 2126)                          \
@@ -383,6 +383,7 @@
 #define HVLM_CONNECTORLOCK "0=Unlock, 1=Lock, 2=Init, 3=No Request"
 #define HVLM_VOLTMEAS "0=Inactive, 1=DCLS With Diode, 2=DCLS Without Diode, 3=Reserved"
 #define HVLM_CHGREADY "0=No Error, 1=AC Not Possible, 2=DC Not Possible, 3=AC & DC Not Possible"
+#define HVLM_CHARGERMODE "0=Standby, 1=AC charging, 3=DC charging, 4=Precharge, 5=Fail, 7=Init"
 
 #define CAN_PERIOD_100MS 0
 #define CAN_PERIOD_10MS 1

--- a/include/vw_mlb_charger.h
+++ b/include/vw_mlb_charger.h
@@ -40,7 +40,7 @@ struct ChargerStatus {
     uint16_t ACvoltage;
     uint16_t HVVoltage;
     int8_t temperature;
-    uint8_t mode;
+    uint8_t mode; // 0=Standby, 1=AC charging, 3=DC charging, 4=Precharge, 5=Fail, 7=Init
     uint16_t current;
     uint8_t MaxACAmps;
     uint8_t PPLim;

--- a/src/vw_mlb_charger.cpp
+++ b/src/vw_mlb_charger.cpp
@@ -569,6 +569,8 @@ void VWMLBClass::DecodeCAN(int id, uint32_t data[2])
         break;
 
     case 0X564: // LAD_01
+        // SerialDEBUG.print("Current charger mode: ");
+        // 0=standby,1=AC charging,3=DC charging,4=Precharge,5=Fail,7=init
         charger_status.mode = ((bytes[1] >> 4) & (0x07U));
         charger_status.ACvoltage = ((bytes[2] & (0xFFU)) << 1) | ((bytes[1] >> 7) & (0x01U));
         charger_status.HVVoltage = (((bytes[4] & (0x03U)) << 8) | (bytes[3] & (0xFFU)));


### PR DESCRIPTION
## Summary
- keep `mode` in `ChargerStatus` as numeric and document value meanings
- expose charger mode values through a new `HVLM_CHARGERMODE` enum string
- tag `mlb_chr_ChargerState` with the new enumeration
- add comment near charger mode decoding for clarity

## Testing
- `make Test` *(fails: No rule to make target 'my_string.o')*

------
https://chatgpt.com/codex/tasks/task_e_688ca58a31a8832b9908b20eaae2daa5